### PR TITLE
fixes: made adjustments to the row gap of the mentors images and image caption overlap on image 

### DIFF
--- a/public/styles/custom-css/mentors.css
+++ b/public/styles/custom-css/mentors.css
@@ -289,7 +289,7 @@ body{
 
 	grid-column-gap: 45px;	
 
-	grid-row-gap: 40px;
+	grid-row-gap: 60px;
 
 	margin: 0 auto;	
 
@@ -338,6 +338,8 @@ body{
 	align-items: center;
 
 	max-width: 300px;
+
+	max-height: 70px;
 
 	text-align: left;
 
@@ -512,6 +514,10 @@ body{
 	margin-bottom: 7em;
 }
 
+.mentor10 {
+	margin-bottom: -1em;
+}
+
 }
 
 @media(max-width: 332px){
@@ -524,3 +530,4 @@ body{
 	font-size: 24px;
 
 	}
+}


### PR DESCRIPTION
Live URL: https://temofedev.github.io/hngi8-mentors-page/

screenshot: 
![Screenshot (33)](https://user-images.githubusercontent.com/16986485/88894743-a4a55b80-d248-11ea-950f-4d3cfe4c03dd.png)
